### PR TITLE
fix: Remove backend spec from proto

### DIFF
--- a/plugin/v3/plugin.proto
+++ b/plugin/v3/plugin.proto
@@ -22,21 +22,6 @@ service Plugin {
   rpc Close(Close.Request) returns (Close.Response);
 }
 
-enum Registry {
-  REGISTRY_UNSPECIFIED = 0;
-  REGISTRY_GITHUB = 1;
-  REGISTRY_GRPC = 2;
-  REGISTRY_LOCAL = 3;
-}
-
-message StateBackendSpec {
-  string name = 1;
-  string path = 2;
-  string version = 3;
-  Registry registry = 4;
-  bytes spec = 5;
-}
-
 message GetName {
   message Request {}
   message Response {
@@ -95,9 +80,8 @@ message Sync {
   message Request {
     repeated string tables = 1;
     repeated string skip_tables = 2;
-    StateBackendSpec state_backend = 3;
+    bool skip_dependent_tables = 3;
     bool deterministic_cq_id = 4;
-    bool skip_dependent_tables = 5;
   }
   message Response {
     oneof message {


### PR DESCRIPTION
Similar to other plugin design we make `state` it's own package and unrelated to plugin so plugin author can choose what they want to use.

The biggest advantage is that those components are testable and it doesn't create `N*N` test cases needed to test all options in a plugin.

The dis-advantage is that there will be a bit more code and plugins options can diverge, but as long as authors follow best practices and use the right helpers it should be ok. 


https://github.com/cloudquery/plugin-sdk/pull/984/files#diff-9a35205ef3aae54d2d185cad1ed50972f9deab8f209974f860454a1b54cd187fR1