### PR TITLE
fix: Add `no_connection` to init request

### DIFF
--- a/plugin/v3/plugin.proto
+++ b/plugin/v3/plugin.proto
@@ -42,7 +42,7 @@ message GetVersion {
 message Init {
   message Request {
     bytes spec = 1; // Internal plugin-specific spec
-    bool no_connection = 2; // A flag to indicate plugins should skip connections that require authentication
+    bool no_connection = 2; // A flag to indicate plugins should skip establishing a connection
   }
   message Response {}
 }

--- a/plugin/v3/plugin.proto
+++ b/plugin/v3/plugin.proto
@@ -41,9 +41,8 @@ message GetVersion {
 
 message Init {
   message Request {
-    // Internal plugin-specific spec
-    bytes spec = 1;
-    bool no_connection = 2;
+    bytes spec = 1; // Internal plugin-specific spec
+    bool no_connection = 2; // A flag to indicate plugins should skip connections that require authentication
   }
   message Response {}
 }

--- a/plugin/v3/plugin.proto
+++ b/plugin/v3/plugin.proto
@@ -43,6 +43,7 @@ message Init {
   message Request {
     // Internal plugin-specific spec
     bytes spec = 1;
+    bool no_connection = 2;
   }
   message Response {}
 }


### PR DESCRIPTION
So we can use it to pass the relevant option here https://github.com/cloudquery/plugin-sdk/blob/5671787d774a8454837ceb66b6d59a721b110c16/internal/servers/plugin/v3/plugin.go#L64