### PR TITLE
chore: Trigger Go proto code generation on pushes to main

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,22 @@
+name: Trigger plugin-pb-go code generation
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-gen:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Trigger plugin-pb-go code generation
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_CQ_BOT }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'cloudquery',
+              repo: 'plugin-pb-go',
+              workflow_id: 'regen.yml',
+              ref: 'main',
+            })


### PR DESCRIPTION
Goes with https://github.com/cloudquery/plugin-pb-go/pull/63

Similar to https://github.com/cloudquery/plugin-sdk/blob/5671787d774a8454837ceb66b6d59a721b110c16/.github/workflows/release-pr.yml#L33