### PR TITLE
feat: Add Java generation options

### DIFF
--- a/discovery/v1/discovery.proto
+++ b/discovery/v1/discovery.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 package cloudquery.discovery.v1;
 
 option go_package = "github.com/cloudquery/plugin-pb-go/pb/discovery/v1;discovery";
+option java_package = "io.cloudquery.discovery.v1";
+option java_multiple_files = true;
 
 service Discovery {
   // Get the name of the plugin

--- a/plugin/v3/plugin.proto
+++ b/plugin/v3/plugin.proto
@@ -4,6 +4,8 @@ package cloudquery.plugin.v3;
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/cloudquery/plugin-pb-go/pb/plugin/v3;plugin";
+option java_package = "io.cloudquery.plugin.v3";
+option java_multiple_files = true;
 
 service Plugin {
   // Get the name of the plugin


### PR DESCRIPTION
This ensures the Java package name starts with `io.` and classes are split into multiple files