### PR TITLE
fix(plugin-tables): Add missing `skip_dependent_tables`

### DIFF
--- a/plugin/v3/plugin.proto
+++ b/plugin/v3/plugin.proto
@@ -53,6 +53,7 @@ message GetTables {
   message Request {
     repeated string tables = 1;
     repeated string skip_tables = 2;
+    bool skip_dependent_tables = 3;
   }
   message Response {
     // marshalled []arrow.Schema


### PR DESCRIPTION
This is not part of the protocol, but part of the SDK:
https://github.com/cloudquery/plugin-sdk/blob/ed96059e82c98435e8f365b847dc28f7cdd5f3b1/plugin/options.go#L23

and should be passed in the CLI here:
https://github.com/cloudquery/cloudquery/blob/aedaf67c3334cd5c825404f0f8850b80dd83dc06/cli/cmd/migrate_v3.go#L80

It's used here:
https://github.com/cloudquery/cloudquery/blob/aedaf67c3334cd5c825404f0f8850b80dd83dc06/plugins/source/aws/resources/plugin/client.go#L65