### PR TITLE
feat: Expose `InvocationID` to plugin

### DIFF
--- a/plugin/v3/plugin.proto
+++ b/plugin/v3/plugin.proto
@@ -58,6 +58,7 @@ message Init {
   message Request {
     bytes spec = 1; // Internal plugin-specific spec
     bool no_connection = 2; // A flag to indicate plugins should skip establishing a connection
+    string invocation_id = 3; // unique execution_id that will identify the invocation (sync, migrate etc)
   }
   message Response {}
 }


### PR DESCRIPTION
This is the initial protocol work that will enable plugins to be aware of the ID of the current sync. This will be used to ensure logs include this value as well as higher level features like S3 exposing {{SYNC_ID}} as a parameter in the path