### PR TITLE
feat: Add TransformSchema message.

### DIFF
--- a/plugin/v3/plugin.proto
+++ b/plugin/v3/plugin.proto
@@ -29,6 +29,8 @@ service Plugin {
   rpc Write(stream Write.Request) returns (Write.Response);
   // Transform resources.
   rpc Transform(stream Transform.Request) returns (stream Transform.Response);
+  // Transform schemas.
+  rpc TransformSchema(stream TransformSchema.Request) returns (stream TransformSchema.Response);
   // Send signal to flush and close open connections
   rpc Close(Close.Request) returns (Close.Response);
   // Validate and test the connections used by the plugin
@@ -200,6 +202,17 @@ message Transform {
   message Response {
     // marshalled arrow.Record
     bytes record = 1;
+  }
+}
+
+message TransformSchema {
+  message Request {
+    // marshalled arrow.Schema
+    bytes schema = 1;
+  }
+  message Response {
+    // marshalled arrow.Schema
+    bytes schema = 1;
   }
 }
 


### PR DESCRIPTION
As discussed offline, Transformer plugins are going to need to explicitly provide a synchronous function to transform a schema.

Previously, I implemented a method by which this wasn't necessary, by reusing the existing transform function, but the problem is that we cannot assume that the transform function is not gonna swallow the initial message of a given table, or that it's gonna behave properly with an empty record with a schema.